### PR TITLE
Fix for failing on platform based files.

### DIFF
--- a/Alloy/commands/compile/index.js
+++ b/Alloy/commands/compile/index.js
@@ -398,6 +398,7 @@ function matchesRestriction(files, fileRestriction) {
 		if (typeof file === 'string') {
 			matches |= (file === fileRestriction);
 		} else if (typeof file === 'object') {
+			delete file.platform;
 			matches |= matchesRestriction(file, fileRestriction);
 		} else {
 			throw new Exception('unsupported file type ' + typeof file)


### PR DESCRIPTION
For example for a style file that is `styles/android/mystyle.tss` the file object is, e.g.

```
{ 
  file: {THE FILE NAME},
  platform: true
}
```

`platform: true` ends up throwing an unsupported file type boolean error as you go through your loop.

This is one fix, not sure if removing platform has other side effects...
